### PR TITLE
Replace web search with ddgs and auto-fetch page content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "rich",
     "prompt_toolkit",
     "websocket-client",
+    "ddgs",
+    "beautifulsoup4",
 ]
 requires-python = ">=3.8"
 

--- a/src/ollama_cli/main.py
+++ b/src/ollama_cli/main.py
@@ -496,7 +496,8 @@ You can call multiple tools in one response by repeating the block above."""
                     
                     result = self.execute_tool(name, params)
                     # Show result to user
-                    print_status(f"Result: [dim]{result}[/dim]")
+                    preview = result[:200] + ("..." if len(result) > 200 else "")
+                    print_status(f"Result: [dim]{preview}[/dim]")
                     results.append(f"Tool Result ({name}):\n{result}")
                 
                 if not results:

--- a/src/ollama_cli/tools/web.py
+++ b/src/ollama_cli/tools/web.py
@@ -1,34 +1,74 @@
 import requests
-import urllib.parse
 from .base import tool
 
 @tool(
     name="web_search",
-    description="Search the web for information",
+    description="Search the web for information using DuckDuckGo",
     parameters={
-        "query": {"type": "string", "description": "The search query"}
+        "query": {"type": "string", "description": "The search query"},
+        "max_results": {"type": "integer", "description": "Maximum number of results (default: 5)", "optional": True}
     }
 )
-def web_search(query: str) -> str:
-    """Enhanced web search with DuckDuckGo"""
+def web_search(query: str, max_results: int = 5) -> str:
+    """Web search using DuckDuckGo via ddgs, with page content for top results"""
     try:
-        encoded = urllib.parse.quote(query)
-        # Use DuckDuckGo Instant Answer API
-        api_url = f"https://api.duckduckgo.com/?q={encoded}&format=json"
-        response = requests.get(api_url, timeout=10)
-        data = response.json()
-        
-        results = []
-        if data.get("AbstractText"):
-            results.append(f"Summary: {data['AbstractText']}")
-        
-        for topic in data.get("RelatedTopics", [])[:5]:
-            if isinstance(topic, dict) and "Text" in topic:
-                results.append(f"- {topic['Text']}")
-        
-        return "\n".join(results) if results else "No direct results found. Try a different query."
+        from ddgs import DDGS
+        search_results = []
+        with DDGS() as ddgs:
+            for r in ddgs.text(query, max_results=max_results):
+                search_results.append(r)
+
+        if not search_results:
+            return "No results found. Try a different query."
+
+        output = []
+        # Fetch full page content for top 2 results
+        for i, r in enumerate(search_results):
+            title = r.get("title", "")
+            body = r.get("body", "")
+            href = r.get("href", "")
+            entry = f"**{title}**\n{body}\n{href}"
+
+            if i < 2 and href:
+                content = _fetch_page_content(href)
+                if content:
+                    entry += f"\n\n--- Page Content ---\n{content}"
+
+            output.append(entry)
+
+        return "\n\n".join(output)
+    except ImportError:
+        return "Error: ddgs not installed. Run: pip install ddgs"
     except Exception as e:
         return f"Search error: {str(e)}"
+
+
+def _fetch_page_content(url: str, max_chars: int = 3000) -> str:
+    """Fetch and extract readable text from a URL."""
+    try:
+        response = requests.get(url, timeout=8, headers={
+            "User-Agent": "Mozilla/5.0 (compatible; ollama-cli/3.0)"
+        })
+        response.raise_for_status()
+
+        try:
+            from bs4 import BeautifulSoup
+            soup = BeautifulSoup(response.text, 'html.parser')
+            for tag in soup(["script", "style", "nav", "footer", "header", "aside"]):
+                tag.decompose()
+            text = soup.get_text(separator="\n")
+        except ImportError:
+            text = response.text
+
+        # Clean up whitespace
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        text = "\n".join(lines)
+
+        if len(text) > max_chars:
+            text = text[:max_chars] + "\n... (truncated)"
+        return text
+    except Exception:
+        return ""
 
 @tool(
     name="read_url",


### PR DESCRIPTION
#16 
- Switch from DuckDuckGo Instant Answer API to ddgs package for real search
- Auto-fetch and extract page content for top 2 results using BeautifulSoup
- Truncate tool result display to 200 chars in terminal (full result sent to LLM)
- Add ddgs and beautifulsoup4 as dependencies