### PR TITLE
Add per-session mailbox, resumable sessions, and subagent design doc

### DIFF
--- a/docs/design-subagents.md
+++ b/docs/design-subagents.md
@@ -1,0 +1,106 @@
+# Subagent Architecture — Design Review
+
+## Overview
+
+ollama-cli currently runs a single chat loop: one model, one conversation, sequential tool execution. This proposal adds multi-agent support so the orchestrator can break down complex tasks, delegate to subagents running in parallel, and manage context efficiently.
+
+## Problem
+
+1. Complex tasks require multiple steps (search, read, analyze, write) that block each other sequentially
+2. Different subtasks benefit from different models (coding vs. general reasoning)
+3. Tool results are verbose and fill the context window quickly — a single web search can consume thousands of tokens
+
+## Architecture
+
+Three components:
+
+```
+Orchestrator                    Subagent                     Mailbox File
+    |                              |                              |
+    |-- spawn(task, model, tools)->|                              |
+    |                              |-- {step: "think", ...} ---->|
+    |                              |-- {step: "act", ...} ------>|
+    |                              |-- {step: "observe", ...} -->|
+    |                              |-- {step: "think", ...} ---->|
+    |                              |-- {step: "act", ...} ------>|
+    |                              |-- {step: "observe", ...} -->|
+    |                              |                              |
+    |                              |  (self-summarize)            |
+    |                              |-- {step: "done",             |
+    |                              |    summary: "...",           |
+    |                              |    status: "success"} ----->|
+    |                              |                              |
+    |<--- read ONLY summary -------+------------------------------|
+    |                              |                              |
+    |  (summary enters context)    |  (full trace stays on disk)  |
+```
+
+### Orchestrator (main process)
+
+- Talks to the human
+- Breaks down tasks into subtasks
+- Decides which model each subagent should use (in auto mode)
+- Writes prompts for subagents, hints which tools are relevant
+- Reads mailbox summaries — never the full execution trace
+- Can stop or forget subagents
+
+### Subagent (subprocess)
+
+- Runs a ReACT (Reason + Act) state machine in a separate process
+- Each step is logged to its mailbox file in structured format
+- Has access to a scoped set of tools chosen by the orchestrator
+- On completion, self-summarizes its results before exiting
+- Checks for stop signals between each ReACT step
+
+```
+THINK -> ACT -> OBSERVE -> THINK -> ... -> DONE
+  |                                          |
+  +-------- check stop signal <--------------+
+```
+
+### Mailbox (file-based, not a process)
+
+- Directory: `~/.ollama-cli/mailbox/`
+- One JSONL file per agent: `agent-001.jsonl`
+- Each line is a structured step:
+
+```json
+{"step": "think", "content": "I need to search for weather data", "timestamp": 1709827200}
+{"step": "act", "tool": "web_search", "params": {"query": "weather Cork"}, "timestamp": 1709827201}
+{"step": "observe", "content": "Found temperature 9C, cloudy...", "timestamp": 1709827205}
+{"step": "done", "summary": "Cork is 9C, cloudy with light rain.", "status": "success", "timestamp": 1709827210}
+```
+
+- Stop signal: orchestrator writes `{"signal": "stop"}` to the agent's file
+- Subagent checks for stop signal before each step
+
+## Orchestrator Actions
+
+| Action | When | Effect |
+|--------|------|--------|
+| Read summary | Subagent done | Summary enters orchestrator context |
+| Stop | Taking too long / wrong direction | Write `{signal: "stop"}`, subagent self-summarizes what it has so far, then exits |
+| Forget | Result not needed anymore | Don't read summary at all, just delete/archive the mailbox file |
+| Peek | Debugging / user asks | Read full trace without loading into orchestrator context, show to user directly |
+
+## Context Management
+
+The core design principle: **the orchestrator only ever sees summaries, never raw execution traces.**
+
+- Subagent runs web search, gets 3000 chars of page content, reasons over it in 5 ReACT steps — that's ~10k tokens of trace
+- Orchestrator receives: `"Cork is 9C, cloudy with light rain. 5-day forecast shows highs of 9-10C."` — ~30 tokens
+- Full trace remains in the mailbox JSONL for debugging or user inspection via Peek
+
+This keeps the orchestrator's context window clean and allows it to coordinate many subagents without overflow.
+
+## Constraints
+
+- **Ollama is single-GPU**: requests serialize on one GPU. Parallel subagents are most useful when they use different models or when one is waiting on I/O (web fetch, file read) while another does inference.
+- **Subagent model selection**: orchestrator picks the model. Coding tasks get `qwen2.5-coder:14b`, general tasks get `mistral:latest`, etc. In manual model mode, all subagents use the user's selected model.
+
+## Implementation Plan
+
+1. **Mailbox helpers** — read/write/signal functions for the JSONL mailbox directory
+2. **Subagent ReACT loop** — single subprocess, state machine, writes to mailbox, checks stop signals
+3. **Orchestrator integration** — spawn one subagent from the main chat loop, read its summary
+4. **Multi-agent** — spawn multiple subagents, coordinate results, present to user

--- a/src/ollama_cli/agents/mailbox.py
+++ b/src/ollama_cli/agents/mailbox.py
@@ -1,0 +1,151 @@
+"""
+Mailbox — file-based message passing for subagents.
+
+Each session owns a Mailbox instance whose files live inside the session
+directory: ~/.ollama-cli/sessions/<session_id>/mailbox/
+
+Each agent gets a JSONL file: <mailbox_dir>/<agent_id>.jsonl
+Steps are appended as JSON lines. The orchestrator reads only the
+final summary; full traces stay on disk for debugging.
+"""
+
+import json
+import os
+import time
+import shutil
+from typing import Optional
+
+
+class Mailbox:
+    """Per-session mailbox for subagent communication."""
+
+    def __init__(self, base_dir: str):
+        """Create a mailbox rooted at base_dir.
+
+        Typically: ~/.ollama-cli/sessions/<session_id>/mailbox
+        """
+        self.base_dir = base_dir
+        self.archive_dir = os.path.join(base_dir, "archive")
+
+    def _ensure_dirs(self):
+        os.makedirs(self.base_dir, exist_ok=True)
+        os.makedirs(self.archive_dir, exist_ok=True)
+
+    def _path(self, agent_id: str) -> str:
+        return os.path.join(self.base_dir, f"{agent_id}.jsonl")
+
+    def create(self, agent_id: str, task: str, model: str, tools: list = None) -> str:
+        """Create a new mailbox file for an agent. Returns the file path."""
+        self._ensure_dirs()
+        path = self._path(agent_id)
+        header = {
+            "step": "init",
+            "agent_id": agent_id,
+            "task": task,
+            "model": model,
+            "tools": tools or [],
+            "timestamp": time.time(),
+        }
+        with open(path, "w") as f:
+            f.write(json.dumps(header) + "\n")
+        return path
+
+    def write_step(self, agent_id: str, step: str, **kwargs):
+        """Append a step to an agent's mailbox.
+
+        step: one of "think", "act", "observe", "done", "error"
+        kwargs: content, tool, params, summary, status, etc.
+        """
+        path = self._path(agent_id)
+        entry = {"step": step, "timestamp": time.time(), **kwargs}
+        with open(path, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def read_steps(self, agent_id: str) -> list:
+        """Read all steps from an agent's mailbox."""
+        path = self._path(agent_id)
+        if not os.path.exists(path):
+            return []
+        steps = []
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        steps.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        return steps
+
+    def read_summary(self, agent_id: str) -> Optional[str]:
+        """Read only the final summary from an agent's mailbox.
+
+        Returns None if the agent hasn't finished yet.
+        """
+        steps = self.read_steps(agent_id)
+        for step in reversed(steps):
+            if step.get("step") == "done":
+                return step.get("summary")
+        return None
+
+    def get_status(self, agent_id: str) -> str:
+        """Get the current status of an agent.
+
+        Returns: "unknown", "running", "done", "error", "stopped"
+        """
+        steps = self.read_steps(agent_id)
+        if not steps:
+            return "unknown"
+        last = steps[-1]
+        last_step = last.get("step", "")
+        if last_step == "done":
+            return last.get("status", "done")
+        if last_step == "error":
+            return "error"
+        if last.get("signal") == "stop":
+            return "stopped"
+        return "running"
+
+    def send_signal(self, agent_id: str, signal: str):
+        """Send a signal to a running agent (e.g. 'stop')."""
+        self.write_step(agent_id, "signal", signal=signal)
+
+    def check_signal(self, agent_id: str) -> Optional[str]:
+        """Check if there's a pending signal for this agent.
+
+        Called by the subagent between ReACT steps.
+        Returns the signal string (e.g. 'stop') or None.
+        """
+        steps = self.read_steps(agent_id)
+        for step in reversed(steps):
+            if step.get("step") == "signal":
+                return step.get("signal")
+            if step.get("step") in ("think", "act", "observe", "init"):
+                break
+        return None
+
+    def list_agents(self) -> list:
+        """List all agent IDs with active mailbox files."""
+        self._ensure_dirs()
+        agents = []
+        for f in os.listdir(self.base_dir):
+            if f.endswith(".jsonl"):
+                agents.append(f[:-6])
+        return agents
+
+    def cleanup(self, agent_id: str, archive: bool = True):
+        """Remove an agent's mailbox. Optionally archive it first."""
+        path = self._path(agent_id)
+        if not os.path.exists(path):
+            return
+        if archive:
+            self._ensure_dirs()
+            dest = os.path.join(self.archive_dir, f"{agent_id}_{int(time.time())}.jsonl")
+            shutil.move(path, dest)
+        else:
+            os.remove(path)
+
+    def cleanup_all(self, archive: bool = False):
+        """Remove all mailbox files."""
+        for agent_id in self.list_agents():
+            self.cleanup(agent_id, archive=archive)

--- a/src/ollama_cli/core/sessions.py
+++ b/src/ollama_cli/core/sessions.py
@@ -1,53 +1,148 @@
+"""
+Session management for ollama-cli.
+
+Each session is a directory under ~/.ollama-cli/sessions/<session_id>/ containing:
+  - state.json   — messages, model, checkpoints, metadata
+  - mailbox/     — subagent mailbox files (copied on save)
+"""
+
 import os
 import json
+import shutil
+import uuid
 from datetime import datetime
 from typing import List, Dict, Optional
 
-SESSION_DIR = os.path.expanduser("~/.ollama-cli-sessions")
+SESSION_BASE = os.path.expanduser("~/.ollama-cli/sessions")
+# Legacy path for backwards compat with list_sessions
+_LEGACY_DIR = os.path.expanduser("~/.ollama-cli-sessions")
 
-def save_session(messages: List[Dict], session_name: Optional[str] = None) -> str:
-    """Save conversation session"""
-    os.makedirs(SESSION_DIR, exist_ok=True)
-    if not session_name:
-        session_name = datetime.now().strftime("%Y%m%d_%H%M%S")
-    
-    # Ensure filename is safe
-    safe_name = "".join([c for c in session_name if c.isalnum() or c in (' ', '.', '_', '-')]).strip()
-    session_file = os.path.join(SESSION_DIR, f"{safe_name}.json")
-    
-    with open(session_file, 'w') as f:
-        json.dump({
-            "messages": messages, 
-            "timestamp": datetime.now().isoformat(),
-            "name": session_name
-        }, f, indent=2)
-    return session_file
 
-def load_session(session_name: str) -> Optional[List[Dict]]:
-    """Load conversation session"""
-    session_file = os.path.join(SESSION_DIR, f"{session_name}.json")
-    if not os.path.exists(session_file):
-        # Try without extension if name doesn't have it
-        if not session_name.endswith('.json'):
-            session_file = os.path.join(SESSION_DIR, f"{session_name}.json")
-            
-    if os.path.exists(session_file):
-        with open(session_file, 'r') as f:
-            data = json.load(f)
-            return data.get("messages", [])
+def _safe_name(name: str) -> str:
+    return "".join(c for c in name if c.isalnum() or c in (' ', '.', '_', '-')).strip()
+
+
+def generate_session_id() -> str:
+    """Generate a short unique session ID."""
+    now = datetime.now().strftime("%Y%m%d_%H%M%S")
+    short = uuid.uuid4().hex[:6]
+    return f"{now}_{short}"
+
+
+def _session_dir(session_id: str) -> str:
+    return os.path.join(SESSION_BASE, _safe_name(session_id))
+
+
+def save_session(messages: List[Dict], session_id: Optional[str] = None,
+                 model: str = "", auto_model: bool = True,
+                 checkpoints: list = None) -> str:
+    """Save full session state to a session directory. Returns the session ID."""
+    if not session_id:
+        session_id = generate_session_id()
+
+    sdir = _session_dir(session_id)
+    os.makedirs(sdir, exist_ok=True)
+
+    # Save state
+    state = {
+        "session_id": session_id,
+        "messages": messages,
+        "model": model,
+        "auto_model": auto_model,
+        "checkpoints": checkpoints or [],
+        "timestamp": datetime.now().isoformat(),
+    }
+    with open(os.path.join(sdir, "state.json"), "w") as f:
+        json.dump(state, f, indent=2)
+
+    # Mailbox dir lives inside the session dir — nothing to copy.
+    # The Mailbox instance writes directly to <session_dir>/mailbox/.
+
+    return session_id
+
+
+def load_session(session_id: str) -> Optional[Dict]:
+    """Load full session state. Returns dict with messages, model, checkpoints, etc.
+
+    Returns None if session not found.
+    """
+    sdir = _session_dir(session_id)
+    state_file = os.path.join(sdir, "state.json")
+
+    if not os.path.exists(state_file):
+        # Try legacy single-file format
+        return _load_legacy(session_id)
+
+    with open(state_file, "r") as f:
+        state = json.load(f)
+
+    # Mailbox dir is inside the session dir — Mailbox instance will
+    # read from it directly when initialized with this session's path.
+
+    return state
+
+
+def _load_legacy(session_id: str) -> Optional[Dict]:
+    """Load from old single-file format for backwards compat."""
+    for base in [_LEGACY_DIR, SESSION_BASE]:
+        path = os.path.join(base, f"{session_id}.json")
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                data = json.load(f)
+            return {
+                "session_id": session_id,
+                "messages": data.get("messages", []),
+                "model": "",
+                "auto_model": True,
+                "checkpoints": [],
+            }
     return None
 
+
 def list_sessions() -> List[str]:
-    """List available sessions"""
-    if not os.path.exists(SESSION_DIR):
-        return []
-    sessions = [f.replace('.json', '') for f in os.listdir(SESSION_DIR) if f.endswith('.json')]
+    """List available session IDs, newest first."""
+    sessions = []
+    if os.path.exists(SESSION_BASE):
+        for name in os.listdir(SESSION_BASE):
+            sdir = os.path.join(SESSION_BASE, name)
+            if os.path.isdir(sdir) and os.path.exists(os.path.join(sdir, "state.json")):
+                sessions.append(name)
+    # Also include legacy sessions
+    if os.path.exists(_LEGACY_DIR):
+        for f in os.listdir(_LEGACY_DIR):
+            if f.endswith(".json"):
+                sessions.append(f[:-5])
     return sorted(sessions, reverse=True)
 
-def delete_session(session_name: str) -> bool:
-    """Delete a session"""
-    session_file = os.path.join(SESSION_DIR, f"{session_name}.json")
-    if os.path.exists(session_file):
-        os.remove(session_file)
+
+def delete_session(session_id: str) -> bool:
+    """Delete a session."""
+    sdir = _session_dir(session_id)
+    if os.path.exists(sdir):
+        shutil.rmtree(sdir)
+        return True
+    # Try legacy
+    legacy = os.path.join(_LEGACY_DIR, f"{session_id}.json")
+    if os.path.exists(legacy):
+        os.remove(legacy)
         return True
     return False
+
+
+def get_mailbox_dir(session_id: str) -> str:
+    """Return the mailbox directory path for a session."""
+    return os.path.join(_session_dir(session_id), "mailbox")
+
+
+def get_session_preview(session_id: str) -> str:
+    """Get a short preview of a session (first user message)."""
+    state = load_session(session_id)
+    if not state:
+        return "(empty)"
+    for msg in state.get("messages", []):
+        if msg.get("role") == "user" and not msg["content"].startswith("Tool Result"):
+            preview = msg["content"][:50]
+            if len(msg["content"]) > 50:
+                preview += "..."
+            return preview
+    return "(no messages)"

--- a/src/ollama_cli/main.py
+++ b/src/ollama_cli/main.py
@@ -27,7 +27,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from ollama_cli.core.config import load_config, save_config, update_config
 from ollama_cli.core.ollama import OllamaClient
-from ollama_cli.core.sessions import save_session, load_session, list_sessions
+from ollama_cli.core.sessions import save_session, load_session, list_sessions, generate_session_id, get_session_preview, get_mailbox_dir
+from ollama_cli.agents.mailbox import Mailbox
 from ollama_cli.ui.formatter import console, print_markdown, print_error, print_status, StreamingDisplay
 from prompt_toolkit.formatted_text import HTML
 from ollama_cli.ui.repl import REPL, CheckpointRestore
@@ -48,7 +49,7 @@ from ollama_cli.integrations.notify import start_notify_thread, send_notificatio
 VERSION = "3.0.0"
 
 class OllamaCLI:
-    def __init__(self):
+    def __init__(self, session_id: str = None):
         self.config = load_config()
         self.client = OllamaClient(self.config.get("ollama_url"))
         self.repl = REPL()
@@ -58,8 +59,11 @@ class OllamaCLI:
         self.auto_model = True
         self.system_prompt = self._build_system_prompt()
         self.max_tool_iterations = 5
-        self.checkpoints = []  # list of (messages_copy, model) tuples
+        self.checkpoints = []  # list of (messages_copy, model, prompt_text) tuples
         self.max_checkpoints = 5
+        self._resume_id = session_id  # set if --session was passed
+        self.session_id = session_id or generate_session_id()
+        self.mailbox = Mailbox(get_mailbox_dir(self.session_id))
 
     def _build_system_prompt(self) -> str:
         base_prompt = """You are a highly capable AI assistant powered by Ollama. 
@@ -140,6 +144,43 @@ You can call multiple tools in one response by repeating the block above."""
         self.current_model = model
         print_status(f"Restored to before: [dim]{prompt_text[:60]}[/dim]")
         print_status(f"Model: [bold green]{model}[/bold green] ({len(self.checkpoints)} checkpoints remaining)")
+
+    def _save_and_exit(self):
+        """Auto-save session and exit with resume hint."""
+        # Only save if there are user messages beyond system prompt
+        has_content = any(m.get("role") == "user" for m in self.messages)
+        if has_content:
+            sid = save_session(
+                self.messages,
+                session_id=self.session_id,
+                model=self.current_model,
+                auto_model=self.auto_model,
+                checkpoints=[(m, mdl, txt) for m, mdl, txt in self.checkpoints],
+            )
+            print_status(f"Session saved. Resume with:")
+            console.print(f"  [bold green]ollama-cli --session {sid}[/bold green]\n")
+        else:
+            print_status("Goodbye!")
+        sys.exit(0)
+
+    def _resume_session(self, session_id: str):
+        """Restore state from a saved session."""
+        state = load_session(session_id)
+        if not state:
+            print_error(f"Session '{session_id}' not found.")
+            return False
+        self.session_id = session_id
+        self.messages = state.get("messages", [])
+        model = state.get("model", "")
+        if model:
+            self.current_model = model
+        self.auto_model = state.get("auto_model", True)
+        # Restore checkpoints (stored as lists, convert back to tuples)
+        raw_cp = state.get("checkpoints", [])
+        self.checkpoints = [(cp[0], cp[1], cp[2]) for cp in raw_cp if len(cp) >= 3]
+        print_status(f"Resumed session [bold]{session_id}[/bold]")
+        print_status(f"Model: [bold green]{self.current_model}[/bold green] | {len(self.messages)} messages | {len(self.checkpoints)} checkpoints")
+        return True
 
     def _estimate_tokens(self, text: str) -> int:
         """Rough token estimate (~4 chars per token)."""
@@ -236,7 +277,7 @@ You can call multiple tools in one response by repeating the block above."""
 
 [bold]General Commands:[/bold]
   /help           - Show this help message
-  /quit           - Exit the CLI
+  /quit, /exit    - Save session and exit
   /clear          - Clear conversation history
   /context        - Show context window usage
 
@@ -250,9 +291,9 @@ You can call multiple tools in one response by repeating the block above."""
 [bold]Model & Sessions:[/bold]
   /models         - List available models
   /model <name>   - Switch current model
-  /sessions       - List saved sessions
-  /save [name]    - Save current session
-  /load <name>    - Load a saved session
+  /sessions       - List saved sessions with previews
+  /save [id]      - Save current session
+  /load <id>      - Resume a saved session
 
 [bold]Core Agent Tools:[/bold]
   [blue]Filesystem:[/blue] read_file, write_file, list_directory, grep_search, get_tree
@@ -340,9 +381,8 @@ You can call multiple tools in one response by repeating the block above."""
                         print_error("Usage: /config <ollama|comfy|comfy_path|comfy_output|piper_path|piper_model> <value>")
                 else:
                     print_error("Usage: /config <ollama|comfy|comfy_path|comfy_output|piper_path|piper_model> <value>")
-            elif cmd == '/quit':
-                print_status("Goodbye!")
-                sys.exit(0)
+            elif cmd in ('/quit', '/exit'):
+                self._save_and_exit()
             elif cmd == '/context':
                 self._show_context()
             elif cmd == '/clear':
@@ -404,21 +444,32 @@ You can call multiple tools in one response by repeating the block above."""
                                 print_error(f"Invalid selection: {choice}")
             elif cmd == '/sessions':
                 sessions = list_sessions()
-                print_status(f"Recent sessions: {', '.join(sessions[:10])}")
+                if not sessions:
+                    print_status("No saved sessions.")
+                else:
+                    console.print("\n[bold cyan]Saved Sessions:[/bold cyan]")
+                    for s in sessions[:10]:
+                        preview = get_session_preview(s)
+                        console.print(f"  [dim]{s}[/dim] — {preview}")
+                    console.print("")
             elif cmd == '/save':
-                name = parts[1] if len(parts) > 1 else None
-                path = save_session(self.messages, name)
-                print_status(f"Session saved to {path}")
+                sid = save_session(
+                    self.messages,
+                    session_id=parts[1] if len(parts) > 1 else self.session_id,
+                    model=self.current_model,
+                    auto_model=self.auto_model,
+                    checkpoints=[(m, mdl, txt) for m, mdl, txt in self.checkpoints],
+                )
+                print_status(f"Session saved: [bold]{sid}[/bold]")
+                print_status(f"Resume with: [bold green]ollama-cli --session {sid}[/bold green]")
             elif cmd == '/load':
                 if len(parts) > 1:
-                    messages = load_session(parts[1])
-                    if messages:
-                        self.messages = messages
-                        print_status(f"Session '{parts[1]}' loaded.")
+                    if self._resume_session(parts[1]):
+                        pass  # success message printed by _resume_session
                     else:
                         print_error(f"Session '{parts[1]}' not found.")
                 else:
-                    print_error("Usage: /load <session_name>")
+                    print_error("Usage: /load <session_id>")
             elif cmd == '/mcp':
                 if len(parts) > 3 and parts[1] == 'connect':
                     name = parts[2]
@@ -469,7 +520,7 @@ You can call multiple tools in one response by repeating the block above."""
 
     def run(self):
         console.print(f"[bold cyan]Ollama CLI v{VERSION}[/bold cyan]")
-        
+
         # Initial model detection
         try:
             self.available_models = self.client.get_available_models()
@@ -484,15 +535,21 @@ You can call multiple tools in one response by repeating the block above."""
                         self.current_model = am
                         found_pref = True
                         break
-                
+
                 if not found_pref:
                     self.current_model = self.available_models[0]
-                    
+
                 print_status(f"Using model: [bold green]{self.current_model}[/bold green]")
         except Exception as e:
             print_error(f"Could not connect to Ollama: {e}")
 
-        self.reset_messages()
+        # Resume session if --session was provided, otherwise start fresh
+        resumed = False
+        if self._resume_id:
+            resumed = self._resume_session(self._resume_id)
+
+        if not resumed:
+            self.reset_messages()
         
         # Start notification listener if enabled
         if self.config.get("ntfy", {}).get("enabled"):
@@ -741,18 +798,31 @@ You can call multiple tools in one response by repeating the block above."""
         return f"Unknown tool: {name}"
 
 def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Ollama CLI")
+    parser.add_argument("--session", type=str, default=None,
+                        help="Resume a saved session by ID")
+    args = parser.parse_args()
+
     # Ensure Ctrl+Z (SIGTSTP) uses the default handler so the process can be
     # suspended and resumed with fg.  Some libraries (e.g. prompt_toolkit) may
     # override this; restoring SIG_DFL lets the OS handle it natively.
     if hasattr(signal, "SIGTSTP"):
         signal.signal(signal.SIGTSTP, signal.SIG_DFL)
 
+    cli = None
     try:
-        cli = OllamaCLI()
+        cli = OllamaCLI(session_id=args.session)
         cli.run()
     except KeyboardInterrupt:
-        print_status("Interrupted by user. Exiting.")
-        sys.exit(0)
+        if cli:
+            try:
+                cli._save_and_exit()
+            except SystemExit:
+                pass
+        else:
+            print_status("Interrupted by user. Exiting.")
+            sys.exit(0)
     except Exception as e:
         print_error(f"Fatal error: {e}")
         logger.exception("Fatal error")

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -1,0 +1,183 @@
+"""Tests for the Mailbox class."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from ollama_cli.agents.mailbox import Mailbox
+
+
+class TestMailbox(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="ollama_cli_test_mailbox_")
+        self.mb = Mailbox(self.test_dir)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def test_create_mailbox(self):
+        path = self.mb.create("agent-001", "search weather", "mistral:latest", ["web_search"])
+        self.assertTrue(os.path.exists(path))
+
+        steps = self.mb.read_steps("agent-001")
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(steps[0]["step"], "init")
+        self.assertEqual(steps[0]["task"], "search weather")
+        self.assertEqual(steps[0]["model"], "mistral:latest")
+        self.assertEqual(steps[0]["tools"], ["web_search"])
+
+    def test_write_and_read_steps(self):
+        self.mb.create("agent-002", "test task", "llama3.2:3b")
+        self.mb.write_step("agent-002", "think", content="I need to search")
+        self.mb.write_step("agent-002", "act", tool="web_search", params={"query": "test"})
+        self.mb.write_step("agent-002", "observe", content="Found results")
+        self.mb.write_step("agent-002", "done", summary="Test completed.", status="success")
+
+        steps = self.mb.read_steps("agent-002")
+        self.assertEqual(len(steps), 5)  # init + 4 steps
+        self.assertEqual(steps[1]["step"], "think")
+        self.assertEqual(steps[2]["step"], "act")
+        self.assertEqual(steps[2]["tool"], "web_search")
+        self.assertEqual(steps[3]["step"], "observe")
+        self.assertEqual(steps[4]["step"], "done")
+
+    def test_read_summary_when_done(self):
+        self.mb.create("agent-003", "task", "model")
+        self.mb.write_step("agent-003", "think", content="thinking")
+        self.mb.write_step("agent-003", "done", summary="The answer is 42.", status="success")
+
+        summary = self.mb.read_summary("agent-003")
+        self.assertEqual(summary, "The answer is 42.")
+
+    def test_read_summary_when_not_done(self):
+        self.mb.create("agent-004", "task", "model")
+        self.mb.write_step("agent-004", "think", content="still thinking")
+
+        summary = self.mb.read_summary("agent-004")
+        self.assertIsNone(summary)
+
+    def test_read_summary_nonexistent_agent(self):
+        summary = self.mb.read_summary("agent-nonexistent")
+        self.assertIsNone(summary)
+
+    def test_get_status(self):
+        # Unknown
+        self.assertEqual(self.mb.get_status("agent-ghost"), "unknown")
+
+        # Running
+        self.mb.create("agent-005", "task", "model")
+        self.mb.write_step("agent-005", "think", content="working")
+        self.assertEqual(self.mb.get_status("agent-005"), "running")
+
+        # Done
+        self.mb.write_step("agent-005", "done", summary="done", status="success")
+        self.assertEqual(self.mb.get_status("agent-005"), "success")
+
+    def test_get_status_error(self):
+        self.mb.create("agent-006", "task", "model")
+        self.mb.write_step("agent-006", "error", content="something broke")
+        self.assertEqual(self.mb.get_status("agent-006"), "error")
+
+    def test_send_and_check_signal(self):
+        self.mb.create("agent-007", "task", "model")
+        self.mb.write_step("agent-007", "think", content="working")
+
+        # No signal yet
+        self.assertIsNone(self.mb.check_signal("agent-007"))
+
+        # Send stop
+        self.mb.send_signal("agent-007", "stop")
+        self.assertEqual(self.mb.check_signal("agent-007"), "stop")
+
+    def test_signal_cleared_by_new_step(self):
+        self.mb.create("agent-008", "task", "model")
+        self.mb.send_signal("agent-008", "stop")
+        self.assertEqual(self.mb.check_signal("agent-008"), "stop")
+
+        # Agent writes a new step after seeing the signal
+        self.mb.write_step("agent-008", "think", content="acknowledged stop, summarizing")
+        # Signal should no longer be visible (new step is after it)
+        self.assertIsNone(self.mb.check_signal("agent-008"))
+
+    def test_list_agents(self):
+        self.mb.create("agent-a", "task1", "model")
+        self.mb.create("agent-b", "task2", "model")
+        agents = self.mb.list_agents()
+        self.assertIn("agent-a", agents)
+        self.assertIn("agent-b", agents)
+        self.assertEqual(len(agents), 2)
+
+    def test_cleanup_with_archive(self):
+        self.mb.create("agent-009", "task", "model")
+        self.mb.write_step("agent-009", "done", summary="done", status="success")
+        path = self.mb._path("agent-009")
+        self.assertTrue(os.path.exists(path))
+
+        self.mb.cleanup("agent-009", archive=True)
+        self.assertFalse(os.path.exists(path))
+
+        # Should be in archive
+        archive_files = os.listdir(self.mb.archive_dir)
+        self.assertEqual(len(archive_files), 1)
+        self.assertTrue(archive_files[0].startswith("agent-009_"))
+
+    def test_cleanup_without_archive(self):
+        self.mb.create("agent-010", "task", "model")
+        path = self.mb._path("agent-010")
+        self.assertTrue(os.path.exists(path))
+
+        self.mb.cleanup("agent-010", archive=False)
+        self.assertFalse(os.path.exists(path))
+
+    def test_cleanup_nonexistent(self):
+        # Should not raise
+        self.mb.cleanup("agent-nonexistent")
+
+    def test_cleanup_all(self):
+        self.mb.create("agent-x", "task", "model")
+        self.mb.create("agent-y", "task", "model")
+        self.assertEqual(len(self.mb.list_agents()), 2)
+
+        self.mb.cleanup_all(archive=False)
+        self.assertEqual(len(self.mb.list_agents()), 0)
+
+    def test_steps_have_timestamps(self):
+        self.mb.create("agent-011", "task", "model")
+        self.mb.write_step("agent-011", "think", content="test")
+
+        steps = self.mb.read_steps("agent-011")
+        for step in steps:
+            self.assertIn("timestamp", step)
+            self.assertIsInstance(step["timestamp"], float)
+
+    def test_concurrent_writes(self):
+        """Verify multiple writes don't corrupt the file."""
+        self.mb.create("agent-012", "task", "model")
+        for i in range(50):
+            self.mb.write_step("agent-012", "think", content=f"step {i}")
+
+        steps = self.mb.read_steps("agent-012")
+        self.assertEqual(len(steps), 51)  # init + 50
+
+    def test_separate_mailboxes_are_isolated(self):
+        """Two Mailbox instances with different dirs don't interfere."""
+        other_dir = self.test_dir + "_other"
+        os.makedirs(other_dir, exist_ok=True)
+        try:
+            other_mb = Mailbox(other_dir)
+            self.mb.create("agent-x", "task1", "model")
+            other_mb.create("agent-x", "task2", "model")
+
+            steps1 = self.mb.read_steps("agent-x")
+            steps2 = other_mb.read_steps("agent-x")
+            self.assertEqual(steps1[0]["task"], "task1")
+            self.assertEqual(steps2[0]["task"], "task2")
+        finally:
+            shutil.rmtree(other_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Mailbox:
- Refactor mailbox from module functions to Mailbox class
- Each session owns its own mailbox dir under the session directory
- 17 tests covering create, read, write, signals, cleanup, isolation

Sessions:
- Sessions are now directories (~/.ollama-cli/sessions/<id>/) with state.json (messages, model, checkpoints) and mailbox/ subdir
- Auto-save on /quit, /exit, Ctrl+C, and Ctrl+D with resume hint
- Resume with: ollama-cli --session <id>
- /sessions shows previews of first user message
- Backwards compatible with legacy single-file sessions

Also:
- /quit and /exit both trigger save-and-exit
- Add subagent architecture design doc