### PR TITLE
Add subprocess worker for spawning ReACT agents

### DIFF
--- a/src/ollama_cli/agents/__main__.py
+++ b/src/ollama_cli/agents/__main__.py
@@ -1,0 +1,1 @@
+"""Allow running worker as: python -m ollama_cli.agents.worker <config.json>"""

--- a/src/ollama_cli/agents/worker.py
+++ b/src/ollama_cli/agents/worker.py
@@ -1,0 +1,140 @@
+"""
+Worker — subprocess wrapper for ReACTAgent.
+
+The parent process spawns a worker via spawn_agent(), which runs
+a ReACTAgent in a separate process. Communication happens through
+the shared Mailbox (JSONL files on disk).
+
+Parent process API:
+    pid = spawn_agent(task, model, tools, agent_id, mailbox_dir, ...)
+    status = poll_agent(agent_id, mailbox)
+    summary = stop_agent(agent_id, mailbox)
+
+Subprocess entry point:
+    python -m ollama_cli.agents.worker <config.json>
+"""
+
+import json
+import os
+import sys
+import time
+import subprocess
+import tempfile
+from typing import List, Optional
+
+from ollama_cli.agents.mailbox import Mailbox
+
+# How long stop_agent waits for the agent to summarize and exit
+STOP_TIMEOUT = 30
+
+
+def spawn_agent(task: str, model: str, tools: List[str],
+                agent_id: str, mailbox_dir: str,
+                ollama_url: str = "http://localhost:11434",
+                context: str = "", max_iterations: int = 10) -> subprocess.Popen:
+    """Spawn a ReACTAgent in a subprocess.
+
+    Returns the Popen handle. The agent writes to mailbox_dir/<agent_id>.jsonl.
+    """
+    # Write config to a temp file so we don't hit arg length limits
+    config = {
+        "agent_id": agent_id,
+        "task": task,
+        "model": model,
+        "tools": tools,
+        "mailbox_dir": mailbox_dir,
+        "ollama_url": ollama_url,
+        "context": context,
+        "max_iterations": max_iterations,
+    }
+    config_dir = os.path.join(mailbox_dir, ".configs")
+    os.makedirs(config_dir, exist_ok=True)
+    config_path = os.path.join(config_dir, f"{agent_id}.json")
+    with open(config_path, "w") as f:
+        json.dump(config, f)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "ollama_cli.agents.worker", config_path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc
+
+
+def poll_agent(agent_id: str, mailbox: Mailbox) -> str:
+    """Check the status of a spawned agent.
+
+    Returns: "running", "done", "error", "stopped", or "unknown"
+    """
+    return mailbox.get_status(agent_id)
+
+
+def stop_agent(agent_id: str, mailbox: Mailbox,
+               timeout: int = STOP_TIMEOUT) -> Optional[str]:
+    """Send stop signal and wait for the agent to summarize.
+
+    Returns the summary, or None if the agent didn't finish in time.
+    """
+    mailbox.send_signal(agent_id, "stop")
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status = mailbox.get_status(agent_id)
+        if status in ("success", "done", "error"):
+            return mailbox.read_summary(agent_id)
+        time.sleep(0.5)
+
+    return None
+
+
+def _run_worker(config_path: str):
+    """Entry point for the subprocess. Runs the ReACTAgent."""
+    # Load config
+    with open(config_path, "r") as f:
+        config = json.load(f)
+
+    # Register tools before creating the agent
+    import ollama_cli.tools.filesystem
+    import ollama_cli.tools.system
+    import ollama_cli.tools.web
+    import ollama_cli.tools.git
+    import ollama_cli.tools.code
+    import ollama_cli.tools.knowledge
+    import ollama_cli.tools.memory
+    import ollama_cli.tools.execution
+
+    from ollama_cli.agents.mailbox import Mailbox
+    from ollama_cli.agents.react import ReACTAgent
+    from ollama_cli.core.ollama import OllamaClient
+
+    client = OllamaClient(config["ollama_url"])
+    mailbox = Mailbox(config["mailbox_dir"])
+
+    agent = ReACTAgent(
+        client=client,
+        mailbox=mailbox,
+        agent_id=config["agent_id"],
+        task=config["task"],
+        model=config["model"],
+        tools=config.get("tools"),
+        context=config.get("context", ""),
+        max_iterations=config.get("max_iterations", 10),
+    )
+
+    try:
+        agent.run()
+    except Exception as e:
+        mailbox.write_step(config["agent_id"], "error", content=str(e))
+    finally:
+        # Clean up config file
+        try:
+            os.remove(config_path)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python -m ollama_cli.agents.worker <config.json>", file=sys.stderr)
+        sys.exit(1)
+    _run_worker(sys.argv[1])

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,252 @@
+"""Tests for the worker subprocess wrapper.
+
+These tests spawn real subprocesses but use a mock worker script
+that simulates ReACTAgent behavior without requiring Ollama.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+from ollama_cli.agents.mailbox import Mailbox
+from ollama_cli.agents.worker import poll_agent, stop_agent
+
+# Path to the mock worker script (created in setUp)
+_MOCK_WORKER = None
+
+
+def _write_mock_worker(path: str):
+    """Write a mock worker script that simulates a ReACTAgent."""
+    script = '''
+import json
+import sys
+import time
+import os
+
+def write_step(mailbox_dir, aid, step, **kwargs):
+    p = os.path.join(mailbox_dir, f"{aid}.jsonl")
+    entry = {"step": step, "timestamp": time.time(), **kwargs}
+    with open(p, "a") as f:
+        f.write(json.dumps(entry) + "\\n")
+
+def check_signal(mailbox_dir, aid):
+    p = os.path.join(mailbox_dir, f"{aid}.jsonl")
+    if not os.path.exists(p):
+        return None
+    with open(p, "r") as f:
+        lines = f.readlines()
+    for line in reversed(lines):
+        entry = json.loads(line.strip())
+        if entry.get("step") == "signal_ack":
+            return None
+        if entry.get("step") == "signal":
+            return entry.get("signal")
+    return None
+
+config_path = sys.argv[1]
+with open(config_path, "r") as f:
+    config = json.load(f)
+
+aid = config["agent_id"]
+mailbox_dir = config["mailbox_dir"]
+task = config["task"]
+os.makedirs(mailbox_dir, exist_ok=True)
+
+write_step(mailbox_dir, aid, "init", agent_id=aid,
+           task=task, model=config["model"], tools=config.get("tools", []))
+
+for i in range(3):
+    sig = check_signal(mailbox_dir, aid)
+    if sig == "stop":
+        write_step(mailbox_dir, aid, "done",
+                   summary=f"Stopped after {i} iterations.", status="success")
+        try:
+            os.remove(config_path)
+        except OSError:
+            pass
+        sys.exit(0)
+
+    write_step(mailbox_dir, aid, "think", content=f"Thinking step {i}")
+    time.sleep(0.3)
+
+    write_step(mailbox_dir, aid, "act", tool="mock_tool", params={"i": i})
+    time.sleep(0.1)
+
+    write_step(mailbox_dir, aid, "observe", content=f"Result {i}")
+
+write_step(mailbox_dir, aid, "done",
+           summary=f"Completed task: {task}", status="success")
+
+try:
+    os.remove(config_path)
+except OSError:
+    pass
+'''
+    with open(path, "w") as f:
+        f.write(script)
+
+
+class TestWorker(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="ollama_cli_test_worker_")
+        self.mailbox_dir = os.path.join(self.test_dir, "mailbox")
+        os.makedirs(self.mailbox_dir, exist_ok=True)
+        self.mailbox = Mailbox(self.mailbox_dir)
+
+        # Write mock worker script
+        self.mock_worker_path = os.path.join(self.test_dir, "mock_worker.py")
+        _write_mock_worker(self.mock_worker_path)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def _spawn_mock(self, agent_id: str, task: str = "test task",
+                    model: str = "test-model", tools: list = None) -> subprocess.Popen:
+        """Spawn the mock worker as a subprocess."""
+        config = {
+            "agent_id": agent_id,
+            "task": task,
+            "model": model,
+            "tools": tools or [],
+            "mailbox_dir": self.mailbox_dir,
+            "ollama_url": "http://localhost:11434",
+            "context": "",
+            "max_iterations": 10,
+        }
+        config_dir = os.path.join(self.mailbox_dir, ".configs")
+        os.makedirs(config_dir, exist_ok=True)
+        config_path = os.path.join(config_dir, f"{agent_id}.json")
+        with open(config_path, "w") as f:
+            json.dump(config, f)
+
+        return subprocess.Popen(
+            [sys.executable, self.mock_worker_path, config_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def test_spawn_and_complete(self):
+        """Spawn an agent, wait for it to finish, read summary."""
+        proc = self._spawn_mock("worker-001", task="say hello")
+        proc.wait(timeout=10)
+        self.assertEqual(proc.returncode, 0)
+
+        # Check mailbox
+        status = poll_agent("worker-001", self.mailbox)
+        self.assertEqual(status, "success")
+
+        summary = self.mailbox.read_summary("worker-001")
+        self.assertIsNotNone(summary)
+        self.assertIn("say hello", summary)
+
+    def test_poll_while_running(self):
+        """Poll an agent while it's still running."""
+        proc = self._spawn_mock("worker-002")
+
+        # Give it a moment to start and write init
+        time.sleep(0.3)
+        status = poll_agent("worker-002", self.mailbox)
+        self.assertEqual(status, "running")
+
+        proc.wait(timeout=10)
+        status = poll_agent("worker-002", self.mailbox)
+        self.assertEqual(status, "success")
+
+    def test_stop_signal(self):
+        """Stop an agent mid-execution."""
+        proc = self._spawn_mock("worker-003", task="long task")
+
+        # Wait for it to start
+        time.sleep(0.3)
+        self.assertEqual(poll_agent("worker-003", self.mailbox), "running")
+
+        # Send stop and wait for summary
+        summary = stop_agent("worker-003", self.mailbox, timeout=10)
+        self.assertIsNotNone(summary)
+        self.assertIn("Stopped", summary)
+
+        proc.wait(timeout=5)
+
+    def test_mailbox_has_steps(self):
+        """Verify the mailbox contains expected step types after completion."""
+        proc = self._spawn_mock("worker-004")
+        proc.wait(timeout=10)
+
+        steps = self.mailbox.read_steps("worker-004")
+        step_types = [s["step"] for s in steps]
+
+        self.assertEqual(step_types[0], "init")
+        self.assertIn("think", step_types)
+        self.assertIn("act", step_types)
+        self.assertIn("observe", step_types)
+        self.assertEqual(step_types[-1], "done")
+
+    def test_multiple_agents(self):
+        """Spawn multiple agents concurrently."""
+        procs = []
+        for i in range(3):
+            p = self._spawn_mock(f"multi-{i}", task=f"task {i}")
+            procs.append(p)
+
+        for p in procs:
+            p.wait(timeout=15)
+
+        for i in range(3):
+            status = poll_agent(f"multi-{i}", self.mailbox)
+            self.assertEqual(status, "success")
+            summary = self.mailbox.read_summary(f"multi-{i}")
+            self.assertIn(f"task {i}", summary)
+
+    def test_list_agents(self):
+        """List running agents."""
+        proc = self._spawn_mock("list-001")
+        proc.wait(timeout=10)
+
+        agents = self.mailbox.list_agents()
+        self.assertIn("list-001", agents)
+
+
+class TestSpawnAgentFunction(unittest.TestCase):
+    """Test the actual spawn_agent function (needs ollama_cli installed)."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="ollama_cli_test_spawn_")
+        self.mailbox_dir = os.path.join(self.test_dir, "mailbox")
+        os.makedirs(self.mailbox_dir, exist_ok=True)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def test_spawn_creates_config(self):
+        """spawn_agent creates a config file and starts a process."""
+        from ollama_cli.agents.worker import spawn_agent
+
+        proc = spawn_agent(
+            task="test",
+            model="nonexistent-model",
+            tools=["web_search"],
+            agent_id="spawn-001",
+            mailbox_dir=self.mailbox_dir,
+            ollama_url="http://localhost:99999",  # intentionally wrong
+        )
+
+        # Process should have started (will fail to connect, but that's ok)
+        self.assertIsNotNone(proc.pid)
+
+        # Config file should have been created
+        config_path = os.path.join(self.mailbox_dir, ".configs", "spawn-001.json")
+        # Config might already be cleaned up if process finished fast
+        # but process should exist
+        proc.wait(timeout=15)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- worker.py wraps ReACTAgent in a subprocess entry point
- spawn_agent() creates config JSON, launches python -m subprocess
- poll_agent() checks mailbox status without blocking
- stop_agent() sends stop signal, waits for summary with timeout
- Config passed via temp JSON file (avoids CLI arg length limits)
- Subprocess registers tools and runs ReACTAgent independently
- Also adds orchestrator context param to ReACTAgent
- 7 worker tests: spawn, poll, stop, mailbox steps, concurrent agents
- 38 total tests passing across mailbox/react/worker